### PR TITLE
Pull ubuntu-22.04 from AWS ECR instead of Docker hub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM public.ecr.aws/lts/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG USER


### PR DESCRIPTION
# Description

Migrate Base Image pull from DockerHub to AWS ECR

Description: This PR updates the base image source from DockerHub to AWS ECR due to rate limit restrictions encountered with unauthenticated pulls. The issue was caused by exceeding DockerHub’s pull rate limits, resulting in failed resolutions for ubuntu:22.04.

To mitigate this, the image is now pulled from AWS Elastic Container Registry (ECR), ensuring improved reliability and uninterrupted access. This change enhances workflow stability and prevents future rate-limit errors.

### Changes:
- Updated base image reference from DockerHub to AWS ECR.

### Impact:
- Eliminates DockerHub pull rate limit issues.
- Improves reliability of image retrieval.
- Aligns with a more scalable and controlled image management approach.