### PR TITLE
Update to build Docker Image with ubuntu user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG USER
-ARG UID
-ARG GID
+ARG USER_ID
+ARG GROUP_ID
 
 # Force apt "--no-install-recommends" to limit the image size
 RUN echo 'APT::Install-Recommends   "0";'   >> /etc/apt/apt.conf.d/99local && \
@@ -79,7 +79,6 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 
-USER $USER
+USER "$USER"
 
-WORKDIR /home/$USER
-
+WORKDIR "/home/$USER"

--- a/create_user.sh
+++ b/create_user.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
+# If not provided, defaults to "ubuntu" with UID and GID of 1000
+USER=${USER:-"ubuntu"}
+USER_ID=${USER_ID:-1000}
+GROUP_ID=${GROUP_ID:-1000}
+
 # Create user
-groupadd -g $GID $USER
-useradd -m -s /bin/bash -u $UID -g $GID $USER
+groupadd -g "$GROUP_ID" "$USER"
+useradd -m -s /bin/bash -u "$USER_ID" -g "$GROUP_ID" "$USER"
 
 # Add the user to sudo group
 apt-get update
 apt-get -qq install sudo
-usermod -aG sudo $USER
+usermod -aG sudo "$USER"
 
 # Add user to sudoers without password
-echo "${USER} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USER
-chmod 0440 /etc/sudoers.d/$USER
+echo "${USER} ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/"$USER"
+chmod 0440 /etc/sudoers.d/"$USER"


### PR DESCRIPTION
# Description

This PR adds the logic to build the docker image with the `ubuntu` user with UID and GID as 1000:1000 respectively, instead of creating the user with the default user and GID:UID present at the time of docker build.

This will ensure consistency in docker image builds, as the runners used in github have the same `ubuntu` user with 1000:1000 as UID and GID. This will help to save time during our workflows as workflows will not be requiring to build the image everytime instead build it once and store it in the registry so that the other jobs can just pull the docker image and use it, saving time and computation power of the runners.